### PR TITLE
refactor: remove global atoms and global selectors

### DIFF
--- a/demo/refactor/index.html
+++ b/demo/refactor/index.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <my-app></my-app>
+    <my-el></my-el>
     <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/demo/refactor/index.html
+++ b/demo/refactor/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <my-app></my-app>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/demo/refactor/index.js
+++ b/demo/refactor/index.js
@@ -1,9 +1,18 @@
-import { LitElement, html, css } from "lit-element";
+import { LitElement, html } from "lit-element";
 import { LitAtom, atom, selector } from "../../index.js";
 
 const [count, setCount] = atom({
   key: 'count',
   default: 1
+});
+
+const [query, getQuery] = atom({
+  key: 'query',
+  loadable: async (id = 1) => {
+    const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`);
+    const body = await res.json();
+    return body;
+  }
 });
 
 const doubleCount = selector({
@@ -30,15 +39,23 @@ console.log(count.getState());
 
 
 class MyEl extends LitAtom(LitElement) {
-  static atoms = [count];
+  static atoms = [count, query];
   static selectors = [doubleCount, doubleCountPlusOne]
 
+  connectedCallback() {
+    super.connectedCallback();
+    getQuery();
+  }
+
   render() {
-    console.log(this.doubleCount)
     return html`
+      <button @click=${() => setCount(old => old + 1)}>click</button>
+      <button @click=${() => getQuery(2)}>loadable</button>
       <div>
-        <button @click=${() => setCount(old => old + 1)}>click</button>
         <span>[COUNT]: ${this.count}</span>
+      </div>
+      <div>
+        <span>[QUERY]: ${this.query.result?.name}</span>
       </div>
       <div>
         <span>[DOUBLECOUNT]: ${this.doubleCount}</span>

--- a/demo/refactor/index.js
+++ b/demo/refactor/index.js
@@ -1,0 +1,11 @@
+// import { LitElement, html, css } from "lit-element";
+import { atom, selector } from "../../index.js";
+
+const [state, setState] = atom({
+  key: 'state',
+  default: 1
+});
+
+console.log(state.getState());
+setState(2);
+console.log(state.getState());

--- a/demo/refactor/index.js
+++ b/demo/refactor/index.js
@@ -31,7 +31,9 @@ const doubleCountPlusOne = selector({
   }
 });
 
-
+console.log(count);
+console.log(query);
+console.log(doubleCount);
 
 console.log(count.getState());
 setCount(2);

--- a/demo/refactor/index.js
+++ b/demo/refactor/index.js
@@ -1,11 +1,19 @@
 // import { LitElement, html, css } from "lit-element";
 import { atom, selector } from "../../index.js";
 
-const [state, setState] = atom({
-  key: 'state',
+const [count, setCount] = atom({
+  key: 'count',
   default: 1
 });
 
-console.log(state.getState());
-setState(2);
-console.log(state.getState());
+const foo = selector({
+  key: 'doubleCount',
+  get: ({getAtom}) => {
+    const c = getAtom(count);
+    return c * 2;
+  }
+});
+
+console.log(count.getState());
+setCount(2);
+console.log(count.getState());

--- a/demo/refactor/index.js
+++ b/demo/refactor/index.js
@@ -1,12 +1,12 @@
-// import { LitElement, html, css } from "lit-element";
-import { atom, selector } from "../../index.js";
+import { LitElement, html, css } from "lit-element";
+import { LitAtom, atom, selector } from "../../index.js";
 
 const [count, setCount] = atom({
   key: 'count',
   default: 1
 });
 
-const foo = selector({
+const doubleCount = selector({
   key: 'doubleCount',
   get: ({getAtom}) => {
     const c = getAtom(count);
@@ -14,6 +14,40 @@ const foo = selector({
   }
 });
 
+const doubleCountPlusOne = selector({
+  key: 'doubleCountPlusOne',
+  get: async ({getSelector}) => {
+    const double = await getSelector(doubleCount);
+    return double + 1;
+  }
+});
+
+
+
 console.log(count.getState());
 setCount(2);
 console.log(count.getState());
+
+
+class MyEl extends LitAtom(LitElement) {
+  static atoms = [count];
+  static selectors = [doubleCount, doubleCountPlusOne]
+
+  render() {
+    console.log(this.doubleCount)
+    return html`
+      <div>
+        <button @click=${() => setCount(old => old + 1)}>click</button>
+        <span>[COUNT]: ${this.count}</span>
+      </div>
+      <div>
+        <span>[DOUBLECOUNT]: ${this.doubleCount}</span>
+      </div>
+      <div>
+        <span>[DOUBLECOUNTPLUSONE]: ${this.doubleCountPlusOne}</span>
+      </div>
+    `
+  }
+}
+
+customElements.define('my-el', MyEl);

--- a/demo/todo-app/todo-debug.js
+++ b/demo/todo-app/todo-debug.js
@@ -8,7 +8,7 @@ const createTodo = id => atom({
   key: id,
   default: { id, text: "", isComplete: false },
   // trigger an update on the `todos` atom whenever a todo is created, to make sure `todos` is in sync
-  effects: [todos.update]
+  effects: [todos.notify.bind(todos)]
 });
 
 const addTodo = () => {

--- a/docs/guides/atoms/index.md
+++ b/docs/guides/atoms/index.md
@@ -94,24 +94,6 @@ setCount(2);
 setCount(old => old + 1);
 ```
 
-### Updating Atoms with the `LitAtom` Mixin
-
-If you're using the `LitAtom` Mixin, you can also call `this.updateAtom`. `updateAtom` takes an Atom, and either a value or a function.
-
-```js
-class MyCounter extends LitAtom(LitElement) {
-  static atoms = [count];
-
-  render() {
-    return html`
-      <h1>count: ${this.count}</h1>
-      <button @click=${() => this.updateAtom(count, old => old + 1)}>increment</button>
-      <button @click=${() => this.updateAtom(count, old => old - 1)}>decrement</button>
-    `;
-  }
-}
-```
-
 ## Sharing Atoms
 
 Atoms can be shared across many different components, independent from eachother. Any component that subscribes to an Atom will be updated and rerendered as soon as that Atom changes.

--- a/docs/guides/integrations/index.md
+++ b/docs/guides/integrations/index.md
@@ -1,0 +1,109 @@
+# Integrations || 2
+
+`@klaxon/atom` is framework agnostic, and can be implemented for usage with your favourite library or framework. There are currently integrations available for usage with [LitElement](https://lit-element.polymer-project.org/), [Haunted](https://github.com/matthewp/haunted), and [Preact](https://preactjs.com/).
+
+## LitElement
+
+You can import the `LitAtom` Mixin, and add any Atoms or Selectors to your component through the `static atoms`/`static selectors` field. This will then make the Atoms and Selectors available on your component instance, based on the `key` provided to the atom. Example:
+
+```js
+import { LitElement, html } from 'lit-element';
+import { LitAtom, atom, selector } from '@klaxon/atom';
+
+const [count] = atom({
+  key: 'count', // The key will be available on your component instance
+  default: 1
+});
+
+const doubleCount = selector({
+  key: 'doubleCount', // The key will be available on your component instance
+  get: ({getAtom}) => {
+    const originalCount = getAtom(count);
+    return originalCount * 2;
+  }
+});
+
+class MyElement extends LitAtom(LitElement) {
+  static atoms = [count];
+  static selectors = [doubleCount];
+
+  render() {
+    return html`
+      <div>${this.count}</div>
+      <div>${this.doubleCount}</div>
+    `;
+  }
+}
+```
+
+## Haunted
+
+There are also Hooks available for usage with Haunted, or [Preact](#Preact).
+
+```js
+import { component } from 'haunted';
+import { html } from 'lit-html';
+import { atom, selector } from '@klaxon/atom';
+import { useAtom, useSelector } from '@klaxon/atom/integrations/haunted.js';
+
+const [countAtom] = atom({
+  key: 'count',
+  default: 1
+});
+
+const doubleCount = selector({
+  key: 'doubleCount',
+  get: ({getAtom}) => {
+    const originalCount = getAtom(count);
+    return originalCount * 2;
+  }
+});
+
+function MyApp() {
+  const [count, setCount] = useAtom(countAtom);
+  const double = useSelector(doubleCount);
+
+  return html`
+    <div>${count}</div>
+    <div>${doubleCount}</div>
+  `
+}
+
+customElements.define('my-app', component(Counter));
+```
+
+## Preact
+
+Hooks are also available for usage with Preact.
+
+```js
+import { render } from 'preact';
+import { html } from 'htm/preact';
+import { atom, selector } from '@klaxon/atom';
+import { useAtom, useSelector } from '@klaxon/atom/integrations/preact.js';
+
+const [countAtom] = atom({
+  key: 'count',
+  default: 1
+});
+
+const doubleCount = selector({
+  key: 'doubleCount',
+  get: ({getAtom}) => {
+    const originalCount = getAtom(count);
+    return originalCount * 2;
+  }
+});
+
+function MyApp() {
+  const [count, setCount] = useAtom(countAtom);
+  const double = useSelector(doubleCount);
+
+  return html`
+    <div>${count}</div>
+    <div>${doubleCount}</div>
+  `
+}
+
+render(html`<${App} /><${App} />`, document.body);
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ callToActionItems: [{ text: 'get started', href: '/guides/' }]
 
 ![source code](./size.png)
 
-`@klaxon/atom` is a flexible state manager that makes use of modern web platform features like ES Modules, and EventTarget. The [core](https://github.com/thepassle/atom/blob/master/src/core.js) of `@klaxon/atom` is very small and checks in at about `1.6kb` (compressed). There is currently one integration with `LitElement`, but the core concepts are not restricted to or depending on `LitElement`, feel free to implement your own integration using the core.
+`@klaxon/atom` is a flexible state manager that makes use of modern web platform features like ES Modules, and EventTarget. The [core](https://github.com/thepassle/atom/blob/master/src/core.js) of `@klaxon/atom` is very small and checks in at about `1.6kb` (compressed). There is currently an integration for `LitElement`, `Haunted`, and `Preact`, but the core concepts are not restricted to or depending to these libraries, feel free to implement your own integration using the core.
 
 You can start using `@klaxon/atom` incrementally in your apps as you require shared state, or even combine it with other state managers.
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 // export { registerDevtools } from './src/devtools.js';
-// export { LitAtom } from './integrations/lit.js';
+export { LitAtom } from './integrations/lit.js';
 export { atom, selector } from './src/core.js';

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-export { registerDevtools } from './src/devtools.js';
-export { LitAtom } from './integrations/lit.js';
+// export { registerDevtools } from './src/devtools.js';
+// export { LitAtom } from './integrations/lit.js';
 export { atom, selector } from './src/core.js';

--- a/integrations/lit.js
+++ b/integrations/lit.js
@@ -1,5 +1,3 @@
-import { updateAtom } from '../src/core.js';
-
 export const LitAtom = (klass) => class LitAtom extends klass {
   constructor() {
     super();
@@ -13,7 +11,7 @@ export const LitAtom = (klass) => class LitAtom extends klass {
 
     this.constructor.atoms?.forEach((atom) => {
       atom.addEventListener(atom.key, this.__atomUpdate);
-      this[atom.key] = atom.state;
+      this[atom.key] = atom.getState();
       this[`__${atom.key}`] = atom;
     });
 
@@ -75,14 +73,6 @@ export const LitAtom = (klass) => class LitAtom extends klass {
         // console.log(`✅ [UPDATED] <${this.localName}>`);
       });
     }
-  }
-
-  /**
-   * @param {atom} atom 
-   * @param {any | ((oldState: any) => any)} val 
-   */
-  updateAtom(atom, val) {
-    updateAtom(atom, val);
   }
 
   __createDeferredPromise() {

--- a/integrations/lit.js
+++ b/integrations/lit.js
@@ -30,7 +30,7 @@ export const LitAtom = (klass) => class LitAtom extends klass {
   disconnectedCallback() {
     this.constructor.atoms?.forEach((atom) => {
       atom.cleanupEffects.forEach(effect => effect());
-      atom.removeEventListener(key, this.__atomUpdate);
+      atom.removeEventListener(atom.key, this.__atomUpdate);
     });
 
     this.constructor.selectors?.forEach(async (selector) => {

--- a/integrations/lit.js
+++ b/integrations/lit.js
@@ -1,4 +1,4 @@
-import { selectors, updateAtom } from '../src/core.js';
+import { updateAtom } from '../src/core.js';
 
 export const LitAtom = (klass) => class LitAtom extends klass {
   constructor() {
@@ -18,10 +18,10 @@ export const LitAtom = (klass) => class LitAtom extends klass {
     });
 
     this.constructor.selectors?.forEach(async (selector) => {
-      const { key } = await selector;
-      const currSelector = selectors.get(key);
-      currSelector.addEventListener(key, this.__selectorUpdate);
-      this[key] = currSelector.value;
+      const currSelector = await selector;
+      currSelector.addEventListener(currSelector.key, this.__selectorUpdate);
+      this[currSelector.key] = currSelector.value;
+      this[`__${currSelector.key}`] = currSelector;
     });
 
     this.scheduleUpdate();
@@ -34,25 +34,22 @@ export const LitAtom = (klass) => class LitAtom extends klass {
     });
 
     this.constructor.selectors?.forEach(async (selector) => {
-      const { key } = await selector;
-      const currSelector = selectors.get(key);
-      currSelector.removeEventListener(key, this.__selectorUpdate);
+      const currSelector = await selector;
+      currSelector.removeEventListener(selector.key, this.__selectorUpdate);
     });
     super.disconnectedCallback?.();
   }
 
   __atomUpdate(e) {
     const { key } = e.detail;
-    this[key] = this[`__${atom.key}`].getState();
+    this[key] = this[`__${key}`].getState();
     // console.log('[ATOM]', key, this[key])
     this.scheduleUpdate();
   }
 
   __selectorUpdate(e) {
     const { key } = e.detail;
-    const selector = selectors.get(key);
-
-    this[key] = selector.value;
+    this[key] = this[`__${key}`].value;
     // console.log('[SELECTOR]', key, this[key]);
     this.scheduleUpdate();
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@klaxon/atom",
-  "version": "0.0.8",
-  "description": "",
+  "version": "0.1.0",
+  "description": "A flexible state manager",
   "main": "index.js",
+  "module": "index.js",
+  "type": "module",
+  "files": [
+    "index.js",
+    "src",
+    "integrations"
+  ],
   "scripts": {
     "start": "wds --watch --node-resolve",
     "test": "wtr test/**/*.test.js --node-resolve",
@@ -12,7 +19,7 @@
     "devtools:build": "rimraf dist && rollup -c rollup.config.js",
     "devtools:build:watch": "rimraf dist && rollup -c --watch rollup.config.js"
   },
-  "keywords": [],
+  "keywords": ["state", "manager", "atom", "statemanager", "webcomponents", "customelements"],
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/src/Store.js
+++ b/src/Store.js
@@ -15,14 +15,11 @@ export class Atom extends Store {
   state;
   effects = [];
   cleanupEffects = [];
-  // Atoms can have Selectors as dependencies
   loadable;
 
   getState() {
     return this.state;
   }
-
-  
 }
 
 export class Selector extends Store {

--- a/src/Store.js
+++ b/src/Store.js
@@ -17,6 +17,12 @@ export class Atom extends Store {
   cleanupEffects = [];
   // Atoms can have Selectors as dependencies
   loadable;
+
+  getState() {
+    return this.state;
+  }
+
+  
 }
 
 export class Selector extends Store {

--- a/src/Store.js
+++ b/src/Store.js
@@ -3,28 +3,31 @@ class Store extends EventTarget {
   children = new Set();
 
   notify() {
-    this.dispatchEvent(new CustomEvent(this.key, { 
-      detail: {
-        key: this.key
-      } 
-    }));
+    this.dispatchEvent(new CustomEvent(this.key, { detail: {key: this.key} }));
+    this.children?.forEach(child => {
+      this.dispatchEvent(new CustomEvent(child, { detail: {key: child} }));
+    });
   }
 }
 
 export class Atom extends Store {
-  state;
+  #state;
   effects = [];
   cleanupEffects = [];
   loadable;
+  
+  setState(val) {
+    this.#state = typeof val === 'function' ? val(this.getState()) : val;
+    this.notify();
+    this.cleanupEffects = this.effects?.map(effect => effect()) || [];
+  }
 
   getState() {
-    return this.state;
+    return this.#state;
   }
 }
 
 export class Selector extends Store {
   value;
   get;
-  // Selectors can also be dependent on Atoms and other Selectors
-  parents = new Set();
 }

--- a/src/core.js
+++ b/src/core.js
@@ -108,7 +108,6 @@ export const selector = async ({key, get}) => {
    * @returns {any} state
    */
   const getAtom = (atom) => {
-    console.log(atom);
     atom.addEventListener(key, updateSelectorVal);
     parents.add(atom.key);
     atom.children.add(key);
@@ -120,11 +119,10 @@ export const selector = async ({key, get}) => {
    * @returns {Promise<any>} state
    */
   const getSelector = async (parentSelector) => {
-    const { key: parentKey } = await parentSelector;
-    const parent = selectors.get(parentKey);
-    parent.addEventListener(parentKey, updateSelectorVal);
+    const parent = await parentSelector;
+    parent.addEventListener(parent.key, updateSelectorVal);
   
-    parents.add(parentKey);
+    parents.add(parent.key);
     parent.children.add(key);
     return parent.value;
   }

--- a/test/core/core.test.js
+++ b/test/core/core.test.js
@@ -1,5 +1,5 @@
 import { expect, nextFrame } from '@open-wc/testing';
-import { atom, selector, atoms, selectors } from '../../src/core.js';
+import { atom, selector } from '../../src/core.js';
 import { spy } from 'hanbi';
 
 const [A, setA] = atom({key: 'foo', default: 1});
@@ -8,13 +8,6 @@ describe('atoms', () => {
   it('initializes an atom', () => {
     expect(A.key).to.equal('foo');
     expect(A.getState()).to.equal(1);
-  });
-
-  it('initializes an atom and stores it', () => {
-    const stored = atoms.get('foo');
-    expect(stored.key).to.equal('foo');
-    expect(stored.state).to.equal(1);
-    expect(stored.effects).to.deep.equal([]);
   });
 
   it('updates the state of an atom', () => {
@@ -125,7 +118,7 @@ describe('selectors', async () => {
   });
 
   it('initializes a selector', async () => {
-    expect(S).to.deep.equal({ key: 'S' });
+    expect(S.key).to.deep.equal('S');
   });
 
   it('depends on atoms', async () => {
@@ -142,10 +135,9 @@ describe('selectors', async () => {
       }
     });
 
-    expect(selectors.get('doubleCount').value).to.equal(2);
-    selectors.get('doubleCount').active = 1;
+    expect(doubleCount.value).to.equal(2);
     setCount(2);
     await nextFrame();
-    expect(selectors.get('doubleCount').value).to.equal(4);
+    expect(doubleCount.value).to.equal(4);
   });
 });

--- a/test/core/core.test.js
+++ b/test/core/core.test.js
@@ -7,6 +7,9 @@ const [A, setA] = atom({key: 'foo', default: 1});
 describe('atoms', () => {
   it('initializes an atom', () => {
     expect(A.key).to.equal('foo');
+    expect(A.effects).to.deep.equal([]);
+    expect(A.cleanupEffects).to.deep.equal([]);
+    expect(A.loadable).to.equal(undefined);
     expect(A.getState()).to.equal(1);
   });
 

--- a/test/lit/lit.test.js
+++ b/test/lit/lit.test.js
@@ -1,6 +1,6 @@
 import { expect, fixture } from '@open-wc/testing';
 import { LitElement } from 'lit-element';
-import { LitAtom } from '../../src/lit.js';
+import { LitAtom } from '../../integrations/lit.js';
 import { atom, selector } from '../../src/core.js';
 
 const [count, setCount] = atom({

--- a/test/lit/lit.test.js
+++ b/test/lit/lit.test.js
@@ -20,16 +20,10 @@ describe('lit', () => {
       expect(el.count).to.equal(1);
     });
   
-    it('updates correctly with `this.updateAtom`', async () => {
-      const el = await fixture('<basic-atom></basic-atom>');
-      el.updateAtom(count, 2);
-      expect(el.count).to.equal(2);
-    });
-  
     it('updates correctly with `setCount`', async () => {
       const el = await fixture('<basic-atom></basic-atom>');
       setCount(old => old + 1);
-      expect(el.count).to.equal(3);
+      expect(el.count).to.equal(2);
     });
   });
 


### PR DESCRIPTION
# Todo

- [x] atoms
- [x] clean up `Store`, `Atom`, `Selector` APIs
- [x] fix JSDoc types
- [x] loadable atoms
- [x] selectors
- [x] tests
- [ ] fix hooks integration
  - [ ] preact
  - [ ] haunted
- [x] update docs
  - `this.updateAtom` was removed
  - `atom.update` was removed (although I dont think it was documented anywhere)